### PR TITLE
Use importances instead of perm_importances

### DIFF
--- a/examine_interpretation.ipynb
+++ b/examine_interpretation.ipynb
@@ -35,7 +35,7 @@
     "    \"\"\"\n",
     "    \"\"\"\n",
     "    # Todo - loss of accuracy as output instead of raw accuracy\n",
-    "    abs_importances = list(map(abs, perm_importances))\n",
+    "    abs_importances = list(map(abs, importances))\n",
     "    total_importance = (sum(abs_importances))\n",
     "    importance_shares = list(map(lambda x: x/total_importance, abs_importances))\n",
     "\n",


### PR DESCRIPTION
Previously,  perm_importances was used to compute abs_importances in examine_interpretation. 
As perm_importances does not appear in function arguments, I assumed it should not be used inside it.